### PR TITLE
fix CMakeLists for Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(DockerClient)
 
 set(CMAKE_CXX_STANDARD 20)
 
-include(FindCurl)
+include(FindCURL)
 
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 add_library(
         ${PROJECT_NAME} docker.cpp


### PR DESCRIPTION
Исправлено построение под Ubuntu:
-  минимальная версия CMake установлена в 3.15
-  исправлено название команды (была проблема с регистром)