### PR TITLE
Set curl timeout greater than user code timeout

### DIFF
--- a/src/docker.cpp
+++ b/src/docker.cpp
@@ -256,7 +256,11 @@ JSON_DOCUMENT Docker::requestAndParse(Method method, const std::string & path,
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &str);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10);  // timeout for the URL to download
+
+    // Timeout in seconds for communication with docker.
+    // 10 seconds is limit for user code & tests execution,
+    // 2 seconds are for HTTP overhead:
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10 + 2);
 
     if (method == Method::POST) {
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, paramString.c_str());


### PR DESCRIPTION
Для выполнения пользовательского кода у нас выставлен таймаут в 10 секунд. Если для курла поставить такой же, то мы будем возвращать не ошибку таймаута запуска задачи, а ошибку коммуникации с докером, сопроваожаемую логом:
```
curl_easy_perform() failed: Timeout was reached
```

Решение - поднять таймаут для курла.