### PR TITLE
call .data() to pass string/string_view to curl

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -67,7 +67,7 @@ Response Http::performRequest(detail::Request && request) const {
         }
 
         if (!request.body->data.empty()) {
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.body->data.c_str());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.body->data.data());
             curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, request.body->data.size());
         }
     }
@@ -78,8 +78,8 @@ Response Http::performRequest(detail::Request && request) const {
     }
 
     std::string const full_url = m_baseUrl + request.url;
-    curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
-    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, request.method);
+    curl_easy_setopt(curl, CURLOPT_URL, full_url.data());
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, request.method.data());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &str);


### PR DESCRIPTION
Фикс segmentation fault, проявлявшегося при сборке релиза/дебага под gcc (SUSE Linux) 13.1.1:
![image](https://github.com/ShipilovDmitry/DockerClient/assets/116944723/ba429b28-c763-4c73-9fcf-869d843b4c47)


Причина - string_view передавался как char*. Теперь передается его data().

Дополнительно: c_str() также заменен на data() потому что data() гарантированно указывает на участок памяти, который привязан к строке.