### PR TITLE
Add copyUIDGID field to PutArchive struct

### DIFF
--- a/include/docker/request_params.hpp
+++ b/include/docker/request_params.hpp
@@ -31,6 +31,7 @@ struct PutArchive {
     std::string containerId;
     std::string path;
     std::string archive;  // in memory tar archive
+    std::string copyUIDGID; // If 1 or true, then it will copy UID/GID to the dest file or dir
 };
 
 struct ExecCreate {


### PR DESCRIPTION
Добавление опции copyUIDGID, которая нужна, чтобы передаваемые в контейнер файлы и директории оказывались там не с пользователем и группой рута, а с теми, что у них есть вне контейнера.

Из официальной доки:

> copyUIDGID - string. If 1, true, then it will copy UID/GID maps to the dest file or dir


https://docs.docker.com/reference/api/engine/v1.41/#tag/Container/operation/ContainerArchive