### PR TITLE
Increase timeout for docker

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -85,9 +85,7 @@ Response Http::performRequest(detail::Request && request) const {
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &str);
 
     // Timeout in seconds for communication with docker.
-    // 10 seconds is limit for user code & tests execution,
-    // 2 seconds are for HTTP overhead:
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10 + 2);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 60 * 2);
 
     auto res = curl_easy_perform(curl);
     if (res != CURLE_OK) {


### PR DESCRIPTION
DockerClient - либо общего назначения, поэтому давай не ставить в ней маленькие таймауты. А то у нас и так есть таймауты: в вотчмене (run.sh), в хэндимене, в сцене (гуникорн), в nginx (прокси таймаут), в яваскрипте (на фетч контента). Это какой-то ад все это синхронизировать. Поэтому давай выставим две минуты и забудем про это.